### PR TITLE
fixing unaccounted tag value in systemDuration

### DIFF
--- a/data/vertex_module/tags/hack.lua
+++ b/data/vertex_module/tags/hack.lua
@@ -50,7 +50,7 @@ local function parser(node)
         hack.systemDurations[systemDuration:name()] = sysDurations
         
         if not systemDuration:value() then error("hack nested system tag "..tostring(systemDuration:name()).." requires a duration!") end
-        sysDurations.duration = tonumber(node:first_attribute("duration"):value())
+        sysDurations.duration = tonumber(systemDuration:value() or node:first_attribute("duration"):value())
         if not sysDurations.duration then error("Invalid number for hack nested system tag "..tostring(systemDuration:name()).."!") end
         
         if systemDuration:first_attribute("immuneAfterHack") then


### PR DESCRIPTION
In specified systems the node:first_attribute("duration"):value() safeguard was present without the actual tag value presented, resulting in the hacktime always being the one of the parent node, despite the intention that the value would overwrite hack time for specified systems.

The safeguard is in itself redundant and can be safely removed considering the validator above.